### PR TITLE
Update releng to allow optional bitcode/prefixing of symbols

### DIFF
--- a/devkit.py
+++ b/devkit.py
@@ -267,6 +267,7 @@ class CompilerApplication:
         if objcopy is not None:
             # New option to prevent renaming, to avoid erroneous bitcode symbols
             if self.prefix_syms:
+                print("PREFIX IS GO!!!!")
                 renames = "\n".join([f"{original} {renamed}" for original, renamed in thirdparty_symbol_mappings]) + "\n"
                 with tempfile.NamedTemporaryFile() as renames_file:
                     renames_file.write(renames.encode("utf-8"))

--- a/devkit.py
+++ b/devkit.py
@@ -263,10 +263,10 @@ class CompilerApplication:
 
         objcopy = meson_config.get("objcopy", None)
         if objcopy is not None:
-            llvm_dis = [objcopy[0].replace("-objcopy", "-dis")]
-            llvm_as = [llvm_dis[0].replace("-dis", "-as")]
-            print("Generating symbol mappings...")
-            thirdparty_symbol_mappings = get_thirdparty_symbol_mappings(output_path, meson_config)
+            # llvm_dis = [objcopy[0].replace("-objcopy", "-dis")]
+            # llvm_as = [llvm_dis[0].replace("-dis", "-as")]
+            # print("Generating symbol mappings...")
+            # thirdparty_symbol_mappings = get_thirdparty_symbol_mappings(output_path, meson_config)
 
             """
                 If there is llvmbc then we must patch the bitcode too.
@@ -277,13 +277,13 @@ class CompilerApplication:
             """
             # rename_symbols_in_library(str(output_path), thirdparty_symbol_mappings, objcopy, llvm_dis, llvm_as)
 
-            renames = "\n".join([f"{original} {renamed}" for original, renamed in thirdparty_symbol_mappings]) + "\n"
-            with tempfile.NamedTemporaryFile() as renames_file:
-                renames_file.write(renames.encode("utf-8"))
-                renames_file.flush()
-                subprocess.run(objcopy + ["--redefine-syms=" + renames_file.name, output_path],
-                               check=True)
-
+            # renames = "\n".join([f"{original} {renamed}" for original, renamed in thirdparty_symbol_mappings]) + "\n"
+            # with tempfile.NamedTemporaryFile() as renames_file:
+            #     renames_file.write(renames.encode("utf-8"))
+            #     renames_file.flush()
+            #     subprocess.run(objcopy + ["--redefine-syms=" + renames_file.name, output_path],
+            #                    check=True)
+            thirdparty_symbol_mappings = []
         else:
             thirdparty_symbol_mappings = []
 

--- a/devkit.py
+++ b/devkit.py
@@ -267,7 +267,8 @@ class CompilerApplication:
         if objcopy is not None:
             # New option to prevent renaming, to avoid erroneous bitcode symbols
             if self.prefix_syms:
-                print("PREFIX IS GO!!!!")
+                thirdparty_symbol_mappings = get_thirdparty_symbol_mappings(output_path, meson_config)
+
                 renames = "\n".join([f"{original} {renamed}" for original, renamed in thirdparty_symbol_mappings]) + "\n"
                 with tempfile.NamedTemporaryFile() as renames_file:
                     renames_file.write(renames.encode("utf-8"))

--- a/devkit.py
+++ b/devkit.py
@@ -263,7 +263,21 @@ class CompilerApplication:
 
         objcopy = meson_config.get("objcopy", None)
         if objcopy is not None:
+            llvm_dis = [objcopy[0].replace("-objcopy", "-dis")]
+            llvm_as = [llvm_dis[0].replace("-dis", "-as")]
+            print("Generating symbol mappings...")
             thirdparty_symbol_mappings = get_thirdparty_symbol_mappings(output_path, meson_config)
+
+            """
+                If there is llvmbc then we must patch the bitcode too.
+                1. Check for the llvmbc section
+                2. Extract the IR from the .o
+                3. Patch the IR
+                4. Re-assemble the .o
+            """
+            new_archive = rename_symbols_in_library(str(output_path), thirdparty_symbol_mappings, objcopy, llvm_dis, llvm_as)
+            if new_archive:
+                output_path = new_archive
 
             renames = "\n".join([f"{original} {renamed}" for original, renamed in thirdparty_symbol_mappings]) + "\n"
             with tempfile.NamedTemporaryFile() as renames_file:
@@ -533,3 +547,156 @@ def tweak_flags(cflags, ldflags):
 
 def deduplicate(items):
     return list(OrderedDict.fromkeys(items))
+
+
+def identify_bitcode_files(extract_dir):
+    """Identify bitcode-enabled object files."""
+    bitcode_files = []
+    for obj_file in os.listdir(extract_dir):
+        obj_path = os.path.join(extract_dir, obj_file)
+        # Check if the file is LLVM bitcode
+        result = subprocess.run(['readelf', '-S', obj_path], capture_output=True, text=True)
+        if '.llvmbc' in result.stdout:
+            bitcode_files.append(obj_path)
+    return bitcode_files
+
+
+def disassemble_bitcode(llvm_dis, bitcode_file):
+    """Disassemble a bitcode object file into LLVM IR (.ll)."""
+    ll_file = bitcode_file.replace('.bc', '.ll')
+    subprocess.run(llvm_dis + [bitcode_file, '-o', ll_file], check=True)
+    return ll_file
+
+
+def rename_symbols_in_ll(ll_file, rename_pairs):
+    """Rename symbols in the LLVM IR file using sed."""
+    print(f"[+] Renaming symbols in {ll_file}")
+    for old_symbol, new_symbol in rename_pairs:
+        with open(ll_file, 'r') as file:
+            lines = file.readlines()
+
+        # Regular expression to match function declarations, definitions, and calls for the specific symbol
+        # Prepare a list to hold modified lines
+        modified_lines = []
+        cautious_symbol = "file" == old_symbol or "load" == old_symbol or "store" == old_symbol or "free" == old_symbol or "alloca" == old_symbol
+        if cautious_symbol:
+            print(f"Cautious symbol: {old_symbol}")
+
+        pattern = rf'\B\@{old_symbol}\b'
+
+        for line in lines:
+            if cautious_symbol:
+                if 'define ' not in line and 'declare ' not in line and 'call ' not in line:
+                    modified_lines.append(line)
+                    continue
+            
+            # modified_line = line.replace(f"@{old_symbol}", f"@{new_symbol}")
+            modified_line = re.sub(pattern, f"@{new_symbol}", line)
+            modified_lines.append(modified_line)
+
+        # Write the modified lines back to the file
+        with open(ll_file, 'w') as file:
+            file.writelines(modified_lines)
+
+
+def reassemble_bitcode(llvm_as, ll_file):
+    """Reassemble the modified LLVM IR file back to a bitcode object file."""
+    bitcode_file = ll_file.replace('.ll', '.bc')
+    subprocess.run(llvm_as + [ll_file, '-o', bitcode_file], check=True)
+    return bitcode_file
+
+
+def rebuild_library(extract_dir, output_library_path):
+    """Rebuild the static library from modified object files."""
+    object_files = [f for f in os.listdir(extract_dir) if f.endswith('.o')]
+    subprocess.run(['ar', 'rcs', output_library_path] + object_files, cwd=extract_dir, check=True)
+
+
+def extract_bitcode(objcopy, obj_file, bitcode_path):
+    """Extract the .llvmbc section from an object file."""
+    subprocess.run(objcopy + ['--dump-section=.llvmbc=' + bitcode_path, obj_file], check=True)
+
+
+def embed_bitcode(objcopy, obj_file, bitcode_path):
+    """Re-embed the modified bitcode back into the object file."""
+    subprocess.run(objcopy + ['--update-section', f'.llvmbc={bitcode_path}', obj_file], check=True)
+
+
+def extract_objects_from_archive(archive_path):
+    """Extract object files from a static library."""
+    extract_dir = tempfile.TemporaryDirectory()
+    if not os.path.exists(extract_dir.name):
+        os.makedirs(extract_dir.name)
+    if os.path.exists(extract_dir.name):
+        print(f"Path does exist: {extract_dir.name}")
+        subprocess.run(['ar', 'x', archive_path], cwd=extract_dir.name, check=True)
+    return extract_dir
+
+
+def process_object_file(object_file, rename_pairs, objcopy, llvm_dis, llvm_as):
+    # print(f"Processing {object_file}")
+    bitcode_path = object_file.replace('.o', '.bc')
+    # print(f"1. extracting bitcode from {object_file}: {bitcode_path}")
+    extract_bitcode(objcopy, object_file, bitcode_path)
+
+    # Disassemble, rename symbols, and reassemble the bitcode
+    # print(f"2. disassembling bitcode: {bitcode_path}")
+    ll_file = disassemble_bitcode(llvm_dis, bitcode_path)
+    # print(f"3. renaming... {ll_file}")
+    # should_copy = False
+    # if "backend-libdwarf_gumsymbolutil-libdwarf.c." in ll_file:
+    #     import shutil
+    #     print("Copying backend-libdwarf_gumsymbolutil-libdwarf.c.ll instead...")
+    #     shutil.copyfile(ll_file, "/tmp/ll.file")
+    #     should_copy = True
+    # sz = (os.path.getsize(ll_file)) /1024
+    # if sz < 30:
+    rename_symbols_in_ll(ll_file, rename_pairs)
+    # else:
+    #     print(f"[!] Skipped {ll_file} due to size: {sz}kb")
+    # if should_copy:
+    #     import shutil
+    #     shutil.copyfile(ll_file, "/tmp/ll_renamed.file")
+    #     should_copy = True
+    # print(f"4. re-assembling bitcode... {ll_file}")
+    modified_bitcode = reassemble_bitcode(llvm_as, ll_file)
+
+    # Re-embed the modified bitcode back into the object file
+    # print(f"5. re-embedding bitcode in {object_file}: {modified_bitcode}")
+    embed_bitcode(objcopy, object_file, modified_bitcode)
+
+
+def rename_symbols_in_library(library_path, rename_pairs, objcopy, llvm_dis, llvm_as):
+    """Main function to handle symbol renaming in a bitcode-enabled static library."""
+    extract_dir = extract_objects_from_archive(library_path)
+    output_library_path = library_path + ".out"
+
+    # Step 1: Identify bitcode-enabled object files
+    bitcode_files = identify_bitcode_files(extract_dir.name)
+    print(f"Total files with bitcode: {len(bitcode_files)}")
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+    num_threads = 1
+
+    # Step 2: split the workload and process the IR
+    with ThreadPoolExecutor(max_workers=num_threads) as executor:
+        # Submit each item to be processed
+        future_to_item = {executor.submit(process_object_file, item, rename_pairs, objcopy, llvm_dis, llvm_as): item for item in bitcode_files}
+
+        # Collect the results as they complete
+        for future in as_completed(future_to_item):
+            item = future_to_item[future]
+            try:
+                # Retrieve the result from each future
+                _result = future.result()
+            except Exception as e:
+                print(f"Error processing item {item}: {e}")        
+
+    # Step 3: Rebuild the static library
+    print("Re-building .a archive.")
+    rebuild_library(extract_dir.name, output_library_path)
+
+    # Clean up the extracted directory
+    extract_dir.cleanup()
+
+    print(f"Modified library saved as {output_library_path}")
+    return output_library_path

--- a/env.py
+++ b/env.py
@@ -142,6 +142,10 @@ def generate_machine_config(machine: MachineSpec,
     else:
         impl = env_generic
 
+    options = {}
+    if 1 == 1:
+        options["EMBED_BITCODE"] = True
+
     impl.init_machine_config(machine,
                              build_machine,
                              is_cross_build,
@@ -152,7 +156,8 @@ def generate_machine_config(machine: MachineSpec,
                              config,
                              outpath,
                              outenv,
-                             outdir)
+                             outdir,
+                             options)
 
     if machine.toolchain_is_msvc:
         builtin_options["b_vscrt"] = str_to_meson(machine.config)

--- a/env.py
+++ b/env.py
@@ -69,7 +69,8 @@ def generate_machine_configs(build_machine: MachineSpec,
                              host_sdk_prefix: Optional[Path],
                              call_selected_meson: Callable,
                              default_library: DefaultLibrary,
-                             outdir: Path) -> tuple[MachineConfig, MachineConfig]:
+                             outdir: Path,
+                             options: dict = {}) -> tuple[MachineConfig, MachineConfig]:
     is_cross_build = host_machine != build_machine
 
     if is_cross_build:
@@ -86,7 +87,8 @@ def generate_machine_configs(build_machine: MachineSpec,
                                     build_sdk_prefix,
                                     call_selected_meson,
                                     default_library,
-                                    outdir)
+                                    outdir,
+                                    options)
 
     if is_cross_build:
         host_config = generate_machine_config(host_machine,
@@ -97,7 +99,8 @@ def generate_machine_configs(build_machine: MachineSpec,
                                               host_sdk_prefix,
                                               call_selected_meson,
                                               default_library,
-                                              outdir)
+                                              outdir,
+                                              options)
     else:
         host_config = build_config
 
@@ -112,7 +115,8 @@ def generate_machine_config(machine: MachineSpec,
                             sdk_prefix: Optional[Path],
                             call_selected_meson: Callable,
                             default_library: DefaultLibrary,
-                            outdir: Path) -> MachineConfig:
+                            outdir: Path,
+                            options: dict = {}) -> MachineConfig:
     config = ConfigParser(dict_type=OrderedDict)
     config["constants"] = OrderedDict()
     config["binaries"] = OrderedDict()
@@ -141,10 +145,6 @@ def generate_machine_config(machine: MachineSpec,
         impl = env_android
     else:
         impl = env_generic
-
-    options = {}
-    if 1 == 1:
-        options["EMBED_BITCODE"] = True
 
     impl.init_machine_config(machine,
                              build_machine,

--- a/env_android.py
+++ b/env_android.py
@@ -17,7 +17,8 @@ def init_machine_config(machine: MachineSpec,
                         config: ConfigParser,
                         outpath: list[str],
                         outenv: dict[str, str],
-                        outdir: Path):
+                        outdir: Path,
+                        options: dict = {}):
     ndk_found = False
     try:
         ndk_root = Path(environ["ANDROID_NDK_ROOT"])
@@ -64,9 +65,10 @@ def init_machine_config(machine: MachineSpec,
     ]
     c_like_flags = [
         "-DANDROID",
-        # "-ffunction-sections",
-        # "-fdata-sections",
     ]
+    if "EMBED_BITCODE" not in options:
+        c_like_flags.append("-ffunction-sections")
+        c_like_flags.append("-fdata-sections")
     cxx_like_flags = []
     cxx_link_flags = [
         "-static-libstdc++",

--- a/env_android.py
+++ b/env_android.py
@@ -64,8 +64,8 @@ def init_machine_config(machine: MachineSpec,
     ]
     c_like_flags = [
         "-DANDROID",
-        "-ffunction-sections",
-        "-fdata-sections",
+        # "-ffunction-sections",
+        # "-fdata-sections",
     ]
     cxx_like_flags = []
     cxx_link_flags = [

--- a/env_apple.py
+++ b/env_apple.py
@@ -18,7 +18,8 @@ def init_machine_config(machine: MachineSpec,
                         config: ConfigParser,
                         outpath: list[str],
                         outenv: dict[str, str],
-                        outdir: Path):
+                        outdir: Path,
+                        options: dict = {}):
     xcenv = {**environ}
     if machine.arch == "arm64eoabi":
         try:

--- a/env_generic.py
+++ b/env_generic.py
@@ -21,7 +21,8 @@ def init_machine_config(machine: MachineSpec,
                         config: ConfigParser,
                         outpath: list[str],
                         outenv: dict[str, str],
-                        outdir: Path):
+                        outdir: Path,
+                        options: dict = {}):
     allow_undefined_symbols = machine.os == "freebsd"
 
     options = config["built-in options"]
@@ -193,8 +194,8 @@ def init_machine_config(machine: MachineSpec,
         c_like_flags += ARCH_C_LIKE_FLAGS_UNIX.get(machine.arch, [])
 
         c_like_flags += [
-            # "-ffunction-sections",
-            # "-fdata-sections",
+            "-ffunction-sections",
+            "-fdata-sections",
         ]
 
         if linker_flavor.startswith("gnu-"):

--- a/env_generic.py
+++ b/env_generic.py
@@ -193,8 +193,8 @@ def init_machine_config(machine: MachineSpec,
         c_like_flags += ARCH_C_LIKE_FLAGS_UNIX.get(machine.arch, [])
 
         c_like_flags += [
-            "-ffunction-sections",
-            "-fdata-sections",
+            # "-ffunction-sections",
+            # "-fdata-sections",
         ]
 
         if linker_flavor.startswith("gnu-"):

--- a/meson_configure.py
+++ b/meson_configure.py
@@ -199,6 +199,10 @@ def configure(sourcedir: Path,
         except deps.BundleNotFoundError as e:
             raise_sdk_not_found(e, "host", host_machine)
 
+    options = {}
+    if '-Dbitcode=true' in extra_meson_options:
+        options["EMBED_BITCODE"] = True
+
     build_config, host_config = \
             env.generate_machine_configs(build_machine,
                                          host_machine,
@@ -208,7 +212,8 @@ def configure(sourcedir: Path,
                                          host_sdk_prefix,
                                          call_selected_meson,
                                          default_library,
-                                         builddir)
+                                         builddir,
+                                         options)
 
     meson_options += [f"--native-file={build_config.machine_file}"]
     if host_config is not build_config:

--- a/mkdevkit.py
+++ b/mkdevkit.py
@@ -50,7 +50,7 @@ def main():
                         action="store_const",
                         dest="prefix_syms",
                         const="prefix_syms",
-                        default=True)
+                        default=False)
     parser.add_argument("--cc",
                         help="C compiler to use",
                         type=lambda v: parse_array_option_value(v, ool_optvals))

--- a/mkdevkit.py
+++ b/mkdevkit.py
@@ -45,6 +45,12 @@ def main():
                         dest="flavor",
                         const="_thin",
                         default="")
+    parser.add_argument("-p", "--prefixsyms",
+                        help="redefine the produced symbols with the frida_ prefix",
+                        action="store_const",
+                        dest="prefix_syms",
+                        const="prefix_syms",
+                        default=True)
     parser.add_argument("--cc",
                         help="C compiler to use",
                         type=lambda v: parse_array_option_value(v, ool_optvals))
@@ -61,6 +67,7 @@ def main():
     machine = options.machine
     outdir = options.outdir.resolve()
     flavor = options.flavor
+    prefix_syms = options.prefix_syms
 
     cc = options.cc
     if cc is not None:
@@ -82,7 +89,7 @@ def main():
         assert meson_config is not None
 
     try:
-        app = devkit.CompilerApplication(kit, machine, meson_config, outdir)
+        app = devkit.CompilerApplication(kit, machine, meson_config, outdir, prefix_syms)
         app.run()
     except subprocess.CalledProcessError as e:
         print(e, file=sys.stderr)


### PR DESCRIPTION
In order to facilitate the building of bitcode, symbol redefining has to be disabled, otherwise the bitcode would need renamed too, which is potentially slow & complicated. This PR allows releng to support prefixing as a feature flag from meson, and adjusts some compiler flags based on whether bitcode is to be embedded.