### PR TITLE
Fix Compilation Errors due to Windows Encoding and Unknown Linker Issues

### DIFF
--- a/devkit.py
+++ b/devkit.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 import itertools
+import locale
 import os
 from pathlib import Path
 import re
@@ -438,9 +439,9 @@ def call_pkgconfig(argv, meson_config):
 
 
 def detect_compiler_argument_syntax(meson_config):
-    if subprocess.run(meson_config["c"],
+    if "Microsoft " in subprocess.run(meson_config["c"],
                       capture_output=True,
-                      encoding="utf-8").stderr.startswith("Microsoft "):
+                      encoding=locale.getpreferredencoding()).stderr:
         return "msvc"
 
     return "unix"

--- a/env_generic.py
+++ b/env_generic.py
@@ -1,3 +1,4 @@
+import locale
 from collections import OrderedDict
 from configparser import ConfigParser
 from pathlib import Path
@@ -74,7 +75,7 @@ def init_machine_config(machine: MachineSpec,
                                           env=environ,
                                           stdout=subprocess.PIPE,
                                           stderr=subprocess.STDOUT,
-                                          encoding="utf-8")
+                                          encoding=locale.getpreferredencoding())
             if process.returncode == 0:
                 mcfg = ConfigParser()
                 mcfg.read(machine_file)
@@ -258,8 +259,8 @@ def detect_linker_flavor(cc: list[str]) -> str:
     linker_version = subprocess.run(cc + ["-Wl,--version"],
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.STDOUT,
-                                    encoding="utf-8").stdout
-    if linker_version.startswith("Microsoft "):
+                                    encoding=locale.getpreferredencoding()).stdout
+    if "Microsoft " in linker_version:
         return "msvc"
     if "GNU ld " in linker_version:
         return "gnu-ld"

--- a/env_generic.py
+++ b/env_generic.py
@@ -1,6 +1,6 @@
-import locale
 from collections import OrderedDict
 from configparser import ConfigParser
+import locale
 from pathlib import Path
 import shutil
 import subprocess


### PR DESCRIPTION
This is the same as my other pull request, it is also a compilation error caused by coding problems. But in addition, there is another problem that it cannot correctly identify my linker, because I am Chinese and there are grammatical differences between Chinese and English, so when I get the version number of linker, Instead of getting output that starts with 'Microsoft', I get output that says`用于 x64 的 Microsoft (R) C/C++ 优化编译器 19.41.34123 版`

Here's another pull request of mine:
[https://github.com/frida/frida-core/pull/1122](https://github.com/frida/frida-core/pull/1122)