### PR TITLE
Add recognition of 'armv6kz-' prefixed tool chains

### DIFF
--- a/env_generic.py
+++ b/env_generic.py
@@ -303,6 +303,10 @@ ARCH_COMMON_FLAGS_UNIX = {
         "-march=armv7-a",
         "-mthumb",
     ],
+    "armv6kz": [
+        "-march=armv6kz",
+        "-mcpu=arm1176jzf-s",
+    ],
     "arm64": [
         "-march=armv8-a",
     ],

--- a/machine_spec.py
+++ b/machine_spec.py
@@ -261,6 +261,7 @@ CPU_FAMILIES = {
     "armbe8":       "arm",
     "armeabi":      "arm",
     "armhf":        "arm",
+    "armv6kz":      "arm",
 
     "arm64":        "aarch64",
     "arm64be":      "aarch64",
@@ -279,6 +280,7 @@ CPU_TYPES = {
     "armbe8":       "armv6",
     "armhf":        "armv7hf",
     "armeabi":      "armv7eabi",
+    "armv6kz":      "armv6",
 
     "arm64":        "aarch64",
     "arm64be":      "aarch64",
@@ -292,6 +294,7 @@ CPU_TYPES_PER_OS_OVERRIDES = {
         "arm":        "armv5t",
         "armbe8":     "armv6t",
         "armhf":      "armv7a",
+        "armv6kz":    "armv6t",
 
         "mips":       "mips1",
         "mipsel":     "mips1",


### PR DESCRIPTION
Many times the tool chains for the venerable arm1176jzf-s starts with the 'armv6kz-' prefix.

This patch just adds detection of this variant, since there is no current armv6 configuration for older cpus