### PR TITLE
env_generic: add another match for lld linker

### DIFF
--- a/env_generic.py
+++ b/env_generic.py
@@ -268,7 +268,7 @@ def detect_linker_flavor(cc: List[str]) -> str:
         return "gnu-ld"
     if "GNU gold " in linker_version:
         return "gnu-gold"
-    if linker_version.startswith("LLD "):
+    if linker_version.startswith("LLD ") or "compatible with GNU linkers" in linker_version:
         return "lld"
     if linker_version.startswith("ld: "):
         return "apple"


### PR DESCRIPTION
When building for termux (/android) I got an error:

```
Downloading toolchain 20250512...
Extracting toolchain...
Downloading SDK 20250512 for linux-x86_64...
Extracting SDK...
Downloading SDK 20250512 for android-arm64...
Extracting SDK...
unknown linker: 'collect2 version 13.3.0'
```

digging into it I see that `/usr/bin/gcc -Wl,--version` (with some environmental variables set) returns:

```
collect2 version 13.3.0
/home/builder/.termux-build/_cache/android-r27c-api-24-v1/bin/ld -plugin /usr/libexec/gcc/x86_64-linux-gnu/13/liblto_plugin.so -plugin-opt=/usr/libexec/gcc/x86_64-linux-gnu/13/lto-wrapper -plugin-opt=-fresolution=/tmp/cc5HFfGj.res -plugin-opt=-pass-through=-lgcc -plugin-opt=-pass-through=-lgcc_s -plugin-opt=-pass-through=-lc -plugin-opt=-pass-through=-lgcc -plugin-opt=-pass-through=-lgcc_s --build-id --eh-frame-hdr -m elf_x86_64 --hash-style=gnu --as-needed -dynamic-linker /lib64/ld-linux-x86-64.so.2 -pie -z now -z relro /usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/Scrt1.o /usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/crti.o /usr/lib/gcc/x86_64-linux-gnu/13/crtbeginS.o -L/usr/lib/gcc/x86_64-linux-gnu/13 -L/usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu -L/usr/lib/gcc/x86_64-linux-gnu/13/../../../../lib -L/lib/x86_64-linux-gnu -L/lib/../lib -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../lib -L/usr/lib/gcc/x86_64-linux-gnu/13/../../.. --version -lgcc --push-state --as-needed -lgcc_s --pop-state -lc -lgcc --push-state --as-needed -lgcc_s --pop-state /usr/lib/gcc/x86_64-linux-gnu/13/crtendS.o /usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/crtn.o
LLD 18.0.3 (compatible with GNU linkers)
```

which is not currently matched in env_generic.py. To fix it, look for the "compatible with GNU linkers" substring for lld as well.