### PR TITLE
deps: create version script specifically for FreeBSD

### DIFF
--- a/deps.py
+++ b/deps.py
@@ -454,7 +454,7 @@ class Builder:
                 symfile = envdir / "toolchain-executable.symbols"
                 symfile.write_text("# No exported symbols.\n", encoding="utf-8")
                 extra_ldflags += [f"-Wl,-exported_symbols_list,{symfile}"]
-            elif self._host_machine.os != "windows":
+            elif self._host_machine.os == "freebsd":
                 verfile = envdir / "toolchain-executable.version"
                 verfile.write_text("\n".join([
                                                  "{",
@@ -463,6 +463,17 @@ class Builder:
                                                  "    __progname;",
                                                  "    environ;",
                                                  "",
+                                                 "  local:",
+                                                 "    *;",
+                                                 "};",
+                                                 ""
+                                             ]),
+                                   encoding="utf-8")
+                extra_ldflags += [f"-Wl,--version-script,{verfile}"]
+            elif self._host_machine.os != "windows":
+                verfile = envdir / "toolchain-executable.version"
+                verfile.write_text("\n".join([
+                                                 "{",
                                                  "  local:",
                                                  "    *;",
                                                  "};",


### PR DESCRIPTION
The version scripts currently consists of something along the lines of:

    {
      global:
        # FreeBSD needs these two:
        __progname;
        environ;

      local:
        *;
    };

When compiling for termux (android) the FreeBSD specific entries __progname and environ causes problems in linking step as they are not defined:
```
[292/297] Linking target subprojects/frida-core/server/frida-server-raw
FAILED: subprojects/frida-core/server/frida-server-raw 
/home/builder/lib/android-ndk-r27c/toolchains/llvm/prebuilt/linux-x86_64/bin/clang -target aarch64-none-linux-android24  -o subprojects/frida-core/server/frida-server-raw subprojects/frida-core/server/frida-server-raw.p/meson-generated_server.c.o subprojects/frida-core/server/frida-server-raw.p/server-glue.c.o -L/data/data/com.termux/files/usr/lib -Wl,--as-needed -Wl,--no-undefined -pie -Wl,-z,relro -Wl,-z,noexecstack -Wl,--gc-sections -Wl,-rpath=/data/data/com.termux/files/usr/lib -Wl,--enable-new-dtags -Wl,--as-needed -Wl,-z,relro,-z,now -Wl,--start-group subprojects/frida-core/src/libfrida-core.a subprojects/frida-core/lib/selinux/libfrida-selinux.a subprojects/frida-core/src/libfrida-helper-backend.a subprojects/frida-gum/gum/libfrida-gum-1.0.a subprojects/frida-core/lib/base/libfrida-base-1.0.a subprojects/frida-gum/bindings/gumjs/libfrida-gumjs-inspector-1.0.a subprojects/frida-core/lib/netif/libfrida-netif.a subprojects/frida-core/lib/pipe/libfrida-pipe.a -Wl,--version-script,/home/builder/.termux-build/frida/src/subprojects/frida-core/server/frida-server.version /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libgio-2.0.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libgobject-2.0.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libffi.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libgmodule-2.0.a -pthread /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libglib-2.0.a -lm /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libiconv.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libpcre2-8.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libz.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libgee-0.8.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libjson-glib-1.0.a -llog /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libcapstone.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libnice.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libgthread-2.0.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libssl.a -ldl /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libcrypto.a -Wl,--export-dynamic -llog /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libsoup-3.0.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libsqlite3.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libpsl.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libbrotlidec.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libbrotlicommon.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libnghttp2.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/gio/modules/libgioopenssl.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libquickjs.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libselinux.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libsepol.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libusrsctp.a -llog /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/liblzma.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libunwind.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libdwarf.a /home/builder/.termux-build/frida/src/deps/sdk-android-arm64/lib/libminizip.a -llog -llog -llog -llog -Wl,--end-group
ld.lld: error: version script assignment of 'global' to symbol '__progname' failed: symbol not defined
ld.lld: error: version script assignment of 'global' to symbol 'environ' failed: symbol not defined
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[293/297] Linking target subprojects/frida-core/inject/frida-inject-raw
```

Fix the issue by only adding __progname and environ to the version script for FreeBSD.

Note that there are a bunch of version scripts checked into the different projects that I also had to patch, but I haven't figured out a good upstream'able fix for those yet