### PR TITLE
Platform: add compile support for VisionOS

### DIFF
--- a/env_apple.py
+++ b/env_apple.py
@@ -139,6 +139,7 @@ APPLE_SDKS = {
     "watchos-simulator": "watchsimulator",
     "tvos":              "appletvos",
     "tvos-simulator":    "appletvsimulator",
+    "xros":              "xros",
 }
 
 APPLE_CLANG_ARCHS = {
@@ -154,6 +155,7 @@ APPLE_MINIMUM_OS_VERSIONS = {
     "ios":          "8.0",
     "watchos":      "9.0",
     "tvos":         "13.0",
+    "xros":         "26.0",
 }
 
 APPLE_BINARIES = [

--- a/machine_spec.py
+++ b/machine_spec.py
@@ -167,7 +167,7 @@ class MachineSpec:
 
     @property
     def is_apple(self) -> str:
-        return self.os in {"macos", "ios", "watchos", "tvos"}
+        return self.os in {"macos", "ios", "watchos", "tvos", "xros"}
 
     @property
     def system(self) -> str:


### PR DESCRIPTION
./configure --host=xros-arm64 --without-prebuilds=sdk:host : success
make : failed ,has to upgrade libffi

FAILED: subprojects/libffi/src/libffi.a.p/aarch64_sysv.S.o 
/Users/test/Downloads/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -target arm64-apple-xros26.0 -isysroot /Users/test/Downloads/Xcode-beta.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS26.0.sdk -Isubprojects/libffi/src/libffi.a.p -Isubprojects/libffi/src -I../subprojects/libffi/src -Isubprojects/libffi -I../subprojects/libffi -Isubprojects/libffi/include -I../subprojects/libffi/include -I../subprojects/libffi/src/aarch64 -fdiagnostics-color=always -DNDEBUG -Wall -Winvalid-pch -std=gnu99 -Oz -g -w -fexceptions -DTARGET=AARCH64 -DFFI_BUILDING_DLL -DFFI_STATIC_BUILD -MD -MQ subprojects/libffi/src/libffi.a.p/aarch64_sysv.S.o -MF subprojects/libffi/src/libffi.a.p/aarch64_sysv.S.o.d -o subprojects/libffi/src/libffi.a.p/aarch64_sysv.S.o -c ../subprojects/libffi/src/aarch64/sysv.S
/var/folders/6d/sxss4211179g7yy3__hxy1nw0000gn/T/sysv-28079c.s:27:2: error: invalid CFI advance_loc expression
 .cfi_def_cfa x1, 40;
 ^