### PR TITLE
releng: use JSON env-state and serialize allowed_prebuilds deterministically

### DIFF
--- a/env_state.py
+++ b/env_state.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .env import MachineConfig
+
+
+@dataclass
+class BuildEnvState:
+    meson: str
+    build: MachineConfig
+    host: Optional[MachineConfig]
+    allowed_prebuilds: List[str]
+    deps: Path
+
+
+def dump_build_env_state(path: Path, state: BuildEnvState):
+    path.write_text(json.dumps({
+        "meson": state.meson,
+        "build": _serialize_machine_config(state.build),
+        "host": _serialize_machine_config(state.host),
+        "allowed_prebuilds": state.allowed_prebuilds,
+        "deps": str(state.deps),
+    }), encoding="utf-8")
+
+
+def load_build_env_state(path: Path) -> BuildEnvState:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+
+    if not isinstance(raw, dict):
+        raise ValueError("invalid env state: expected object")
+
+    meson = _expect_string(raw, "meson")
+    build = _deserialize_machine_config(_expect_object(raw, "build"))
+
+    host_data = raw.get("host")
+    if host_data is None:
+        host = None
+    else:
+        if not isinstance(host_data, dict):
+            raise ValueError("invalid env state: host must be object or null")
+        host = _deserialize_machine_config(host_data)
+
+    allowed_prebuilds = _expect_string_list(raw, "allowed_prebuilds")
+    deps = Path(_expect_string(raw, "deps"))
+
+    return BuildEnvState(
+        meson=meson,
+        build=build,
+        host=host,
+        allowed_prebuilds=allowed_prebuilds,
+        deps=deps,
+    )
+
+
+def _serialize_machine_config(config: Optional[MachineConfig]) -> Optional[Dict[str, Any]]:
+    if config is None:
+        return None
+    return {
+        "machine_file": str(config.machine_file),
+        "binpath": [str(path) for path in config.binpath],
+        "environ": config.environ,
+    }
+
+
+def _deserialize_machine_config(raw: Dict[str, Any]) -> MachineConfig:
+    machine_file = Path(_expect_string(raw, "machine_file"))
+    binpath = [Path(path) for path in _expect_string_list(raw, "binpath")]
+    environ = _expect_string_map(raw, "environ")
+    return MachineConfig(
+        machine_file=machine_file,
+        binpath=binpath,
+        environ=environ,
+    )
+
+
+def _expect_object(raw: Dict[str, Any], key: str) -> Dict[str, Any]:
+    value = raw.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"invalid env state: '{key}' must be an object")
+    return value
+
+
+def _expect_string(raw: Dict[str, Any], key: str) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str):
+        raise ValueError(f"invalid env state: '{key}' must be a string")
+    return value
+
+
+def _expect_string_list(raw: Dict[str, Any], key: str) -> List[str]:
+    value = raw.get(key)
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"invalid env state: '{key}' must be a list of strings")
+    return value
+
+
+def _expect_string_map(raw: Dict[str, Any], key: str) -> Dict[str, str]:
+    value = raw.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"invalid env state: '{key}' must be an object")
+    if not all(isinstance(k, str) and isinstance(v, str) for k, v in value.items()):
+        raise ValueError(f"invalid env state: '{key}' must map strings to strings")
+    return value

--- a/env_state.py
+++ b/env_state.py
@@ -18,11 +18,15 @@ class BuildEnvState:
 
 
 def dump_build_env_state(path: Path, state: BuildEnvState):
+    allowed_prebuilds = state.allowed_prebuilds
+    if not isinstance(allowed_prebuilds, list):
+        allowed_prebuilds = sorted(allowed_prebuilds)
+
     path.write_text(json.dumps({
         "meson": state.meson,
         "build": _serialize_machine_config(state.build),
         "host": _serialize_machine_config(state.host),
-        "allowed_prebuilds": state.allowed_prebuilds,
+        "allowed_prebuilds": allowed_prebuilds,
         "deps": str(state.deps),
     }), encoding="utf-8")
 

--- a/meson_configure.py
+++ b/meson_configure.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 from pathlib import Path
-import pickle
 import platform
 import re
 import shlex
@@ -19,6 +18,7 @@ from mesonbuild.coredata import UserArrayOption, UserBooleanOption, \
         UserComboOption, UserFeatureOption, UserOption, UserStringOption
 
 from . import deps, env
+from .env_state import BuildEnvState, dump_build_env_state
 from .machine_spec import MachineSpec
 from .progress import ProgressCallback, print_progress
 
@@ -228,13 +228,13 @@ def configure(sourcedir: Path,
     if platform.system() == "Windows":
         (builddir / "make.bat").write_text(generate_out_of_tree_make_bat(sourcedir), encoding="utf-8")
 
-    (builddir / "frida-env.dat").write_bytes(pickle.dumps({
-        "meson": meson,
-        "build": build_config,
-        "host": host_config if host_config is not build_config else None,
-        "allowed_prebuilds": allowed_prebuilds,
-        "deps": deps_dir,
-    }))
+    dump_build_env_state(builddir / "frida-env.json", BuildEnvState(
+        meson=meson,
+        build=build_config,
+        host=host_config if host_config is not build_config else None,
+        allowed_prebuilds=allowed_prebuilds,
+        deps=deps_dir,
+    ))
 
 
 def parse_prefix(raw_prefix: str) -> Path:

--- a/meson_make.py
+++ b/meson_make.py
@@ -1,13 +1,13 @@
 import argparse
 import os
 from pathlib import Path
-import pickle
 import shlex
 import shutil
 import sys
 from typing import Callable, Dict, List
 
 from . import env
+from .env_state import load_build_env_state
 from .meson_configure import configure
 
 
@@ -44,7 +44,9 @@ def make(sourcedir: Path,
          targets: List[str],
          environ: Dict[str, str] = os.environ,
          call_meson: Callable = env.call_meson):
-    if not (builddir / "build.ninja").exists():
+    env_state_path = builddir / "frida-env.json"
+
+    if not (builddir / "build.ninja").exists() or not env_state_path.exists():
         configure(sourcedir, builddir, environ=environ)
 
     compile_options = []
@@ -61,18 +63,18 @@ def make(sourcedir: Path,
         "test": ["test"] + test_options,
     }
 
-    env_state = pickle.loads((builddir / "frida-env.dat").read_bytes())
+    env_state = load_build_env_state(env_state_path)
 
-    machine_config = env_state["host"]
+    machine_config = env_state.host
     if machine_config is None:
-        machine_config = env_state["build"]
+        machine_config = env_state.build
     meson_env = machine_config.make_merged_environment(environ)
-    meson_env["FRIDA_ALLOWED_PREBUILDS"] = ",".join(env_state["allowed_prebuilds"])
-    meson_env["FRIDA_DEPS"] = str(env_state["deps"])
+    meson_env["FRIDA_ALLOWED_PREBUILDS"] = ",".join(env_state.allowed_prebuilds)
+    meson_env["FRIDA_DEPS"] = str(env_state.deps)
 
     def do_meson_command(args):
         call_meson(args,
-                   use_submodule=env_state["meson"] == "internal",
+                   use_submodule=env_state.meson == "internal",
                    cwd=builddir,
                    env=meson_env,
                    check=True)


### PR DESCRIPTION
## Summary
- replace pickle-based build env-state persistence with JSON + schema validation
- fix JSON serialization for `allowed_prebuilds` when it is provided as a set
- normalize non-list `allowed_prebuilds` values to a sorted list before writing

## Problem
During `./configure`, build setup can fail with:

```
Object of type set is not JSON serializable
```

This happens when `allowed_prebuilds` is not already a list.

## Why this shape
The serialization fix depends on the JSON env-state implementation, so this PR includes both commits in one focused branch.

## Validation
- `python3 -m py_compile releng/env_state.py`
- `./configure` succeeds
- `make` succeeds in default local build
